### PR TITLE
feat(imap): enable TCP keepalive and improve reconnection strategy

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -156,10 +156,16 @@ func fetchAndProcessEmails(client *imapclient.StandardClient, netflixService *ne
 	)
 }
 
-// handleIMAPFailure increments the failure count and implements an exponential backoff strategy
+// handleIMAPFailure increments the failure count and implements an exponential backoff strategy.
+// First failure reconnects immediately; subsequent failures use exponential backoff.
 func handleIMAPFailure(err error) {
 	failures := imapFailureCount.Add(1)
 	logging.Log.Errorf("IMAP connection error: %v", err)
+
+	if failures == 1 {
+		logging.Log.Warnf("IMAP failed, reconnecting immediately...")
+		return
+	}
 
 	var backoff time.Duration
 	if failures < 5 {

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -2,7 +2,9 @@ package imap
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/emersion/go-imap"
@@ -21,10 +23,21 @@ func NewStandardClient() *StandardClient {
 	}
 }
 
-// Connect establishes a secure connection to the IMAP server using TLS. It returns an error if the connection fails.
+// Connect establishes a secure connection to the IMAP server using TLS with TCP keepalive
+// to prevent NAT/firewall from silently dropping idle connections.
 func (c *StandardClient) Connect(server string) error {
-	cl, err := client.DialTLS(server, nil)
+	host, _, _ := net.SplitHostPort(server)
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	conn, err := tls.DialWithDialer(dialer, "tcp", server, &tls.Config{ServerName: host})
 	if err != nil {
+		return fmt.Errorf("IMAP connection error: %w", err)
+	}
+	cl, err := client.New(conn)
+	if err != nil {
+		_ = conn.Close()
 		return fmt.Errorf("IMAP connection error: %w", err)
 	}
 	c.client = cl


### PR DESCRIPTION
* Enable TCP keepalive (30s) using net.Dialer + tls.DialWithDialer to prevent idle connections from being dropped by NAT/firewalls
* Reconnect immediately on the first IMAP failure (failures == 1)
* Keep 10s backoff for failures 2–4
* Keep exponential backoff for failures >= 5