### PR TITLE
refactor(flow): simplify flow and drop deprecated login auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine as builder
+FROM golang:1.26-alpine as builder
 
 WORKDIR /app
 

--- a/Readme.md
+++ b/Readme.md
@@ -2,42 +2,19 @@
 
 Automated Netflix household location verification through email monitoring and browser automation.
 
-[![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat&logo=go)](https://go.dev/)
+[![Go Version](https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Docker](https://img.shields.io/badge/Docker-Available-2496ED?style=flat&logo=docker)](https://hub.docker.com/r/phd59fr/netflix-household-autovalidator)
 
 ## 📝 Description
 
-This application monitors an IMAP mailbox for emails from Netflix links. It is designed to automate the process of verifying the primary location for Netflix accounts.
-
+This application monitors an IMAP mailbox for Netflix emails containing household verification links and automatically validates them. No manual action required.
 **Key Features:**
-- 📧 Automated IMAP email monitoring
-- 🌐 Headless browser automation (Rod/Chromium)
-- 🔐 Multi-account support with credentials
-- 🧹 Automatic temp directory cleanup
-- 📊 Structured JSON logging with trace IDs
-- 🐳 Docker-ready
-
-## 📂 Code Structure
-
-```
-cmd/
-└── main.go                   # Entry point
-
-internal/
-├── models/                   # Domain types (Config, Email, BrowserResult)
-├── config/                   # Configuration loading
-├── logging/                  # JSON logger setup
-├── imapfetch/               # IMAP client (interface + implementation)
-├── mailparse/               # Email parsing & link extraction
-├── emailprocessor/          # Email workflow orchestration
-└── netflix/                 # Netflix service & browser automation
-```
-
-**Design Patterns:**
-- Clean Architecture (domain models separated)
-- Dependency Injection (interfaces for testability)
-- Repository Pattern (IMAP client abstraction)
+- 📧 Monitors your mailbox for Netflix verification emails
+- ⚡ Automatically validates household location from email links
+- 🧠 Ignores expired or invalid links
+- 📊 Structured JSON logs with trace IDs
+- 🐳 Ready to run with Docker
 
 ## ⚙️ Configuration
 **Edit the `config.yaml` file at the root of the project with the following structure:**
@@ -50,20 +27,8 @@ internal/
      mailbox: "INBOX"
    targetFrom: "info@account.netflix.com"
    targetSubject: "Important : comment mettre à jour votre foyer Netflix"
-
-   filterByAccount: false # if true, the application will only process emails that match the email addresses in the netflixAuth section
-   netflixAuth:
-     - email: "your-netflix-email@example.com" #Optional
-       password: "your-netflix-password" #Optional
-     - email: "your-netflix-email2@example.com" #Optional
-       password: "your-netflix-password2" #Optional
-  ```
+```
 **Note:** Make sure to replace the values with your own information.
-
-
-**Configuration Notes:**
-- `filterByAccount`: When `true`, matches email recipients against `netflixAuth` accounts
-- `netflixAuth`: Optional credentials for automatic login if Netflix requires it
 
 ## 🚀 Usage
 
@@ -83,14 +48,34 @@ go build -o validator ./cmd/main.go
 go test ./...
 ```
 
+### Environment Variables
+
+| Variable        | Description |
+|----------------|------------|
+| EMAIL_IMAP     | IMAP server |
+| EMAIL_LOGIN    | Email login |
+| EMAIL_PASSWORD | Email password |
+| EMAIL_MAILBOX  | Mailbox name |
+| TARGET_FROM    | Expected sender |
+| TARGET_SUBJECT | Expected subject |
+
 ### 🐳 Docker
 
 ```bash
 # Pull image
 docker pull phd59fr/netflix-household-autovalidator
 
-# Run with volume-mounted config
+# Run with volume-mounted yaml config
 docker run -v $(pwd)/config.yaml:/app/config.yaml phd59fr/netflix-household-autovalidator
+
+# Run with environment variables (overrides config.yaml)
+docker run \
+  -e EMAIL_IMAP=imap.example.com:993 \
+  -e EMAIL_LOGIN=your-email@example.com \
+  -e EMAIL_PASSWORD=your-password \
+  -e TARGET_FROM=info@account.netflix.com \
+  -e TARGET_SUBJECT="Important : comment mettre à jour votre foyer Netflix" \
+  phd59fr/netflix-household-autovalidator
 ```
 
 **Docker Hub:** [phd59fr/netflix-household-autovalidator](https://hub.docker.com/r/phd59fr/netflix-household-autovalidator)
@@ -110,40 +95,42 @@ go build -o validator ./cmd/main.go
 ```
 .
 ├── cmd/
-│   └── main.go                      # Application entry point
+│   └── main.go                  # Application entry point
 ├── internal/
-│   ├── models/                      # Domain types
-│   │   ├── config.go                # Config, EmailConfig, NetflixAccount
-│   │   ├── email.go                 # Email struct
-│   │   └── browser.go               # BrowserResult enum
-│   ├── config/
-│   │   └── config.go                # YAML config loader
-│   ├── logging/
-│   │   └── logger.go                # Logrus JSON logger
-│   ├── imapfetch/
-│   │   ├── imap.go                  # Client interface
-│   │   └── client.go                # StandardClient implementation
-│   ├── mailparse/
-│   │   └── parser.go                # Email parsing & link extraction
-│   ├── emailprocessor/
-│   │   └── processor.go             # Email workflow orchestration
-│   └── netflix/
-│       ├── browser.go               # Browser interface
-│       ├── browser_rod.go           # Rod browser implementation
-│       └── service.go               # Netflix logic (filters, handlers)
-├── config.yaml                      # Configuration file
-├── Dockerfile                       # Docker build
-└── go.mod                           # Go module definition
+│   ├── config/                  # Config loading
+│   ├── emailprocessor/          # Email processing workflow
+│   ├── imap/                    # IMAP client
+│   ├── logging/                 # Structured JSON logger
+│   ├── mailparse/               # Email parsing & link extraction
+│   ├── models/                  # Domain models (Config, Email, BrowserResult)
+│   └── netflix/                 # Netflix service & browser automation
+├── config.yaml                  # Optional YAML configuration
+├── Dockerfile                   # Container build
+├── .github/workflows/           # CI/CD (Docker build & publish)
+├── go.mod / go.sum              # Dependencies
+└── LICENSE
 ```
+
+## 🏗️ Architecture
+- Event-driven flow based on IMAP IDLE (reacts to incoming emails)
+- Pipeline processing: fetch → parse → filter → handle → mark as seen
+- Clear separation between:
+   - domain (`models`)
+   - infrastructure (`imap`, `netflix`, `logging`)
+   - orchestration (`emailprocessor`)
+- Dependency injection via interfaces:
+   - `imap.Client` for email access
+   - `netflix.Browser` for browser automation
+- Service layer (`netflix.Service`) encapsulating business logic
 
 ## 🔧 How It Works
 
 1. **Monitoring**: Uses IMAP IDLE to subscribe for unseen emails from last 15 minutes
 2. **Filtering**: Checks email sender (`targetFrom`) and subject (`targetSubject`)
 3. **Parsing**: Extracts `update-primary-location` links from email body
-4. **Automation**: Opens link in headless browser (Rod + Chromium)
+4. **Automation**: Opens the validation link in a headless browser and completes the confirmation
    - Accepts cookie banners
-   - Detects and fills login forms (if credentials provided)
+   - Detects login requirement and aborts if authentication is needed
    - Clicks confirmation button
    - Detects expired links
 5. **Marking**: Marks email as read only if successfully handled

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,7 +76,7 @@ func main() {
 			continue
 		}
 
-		// New mail signalled — loop back to fetch and process
+		// New mail signalled - loop back to fetch and process
 	}
 }
 

--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,3 @@ email:
   mailbox: "INBOX"
 targetFrom: "info@account.netflix.com"
 targetSubject: "Important : comment mettre à jour votre foyer Netflix"
-filterByAccount: false #If true, the script will only forward emails from the account specified in the next field
-netflixAuth:
-  - email: user1@example.com
-    password: password1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,15 +10,40 @@ import (
 
 // Load reads the configuration from the specified YAML file and returns a Config struct
 func Load(filepath string) (*models.Config, error) {
-	configFile, err := os.ReadFile(filepath)
-	if err != nil {
-		return nil, err
+	var cfg models.Config
+
+	// Load YAML (optional)
+	if filepath != "" {
+		data, err := os.ReadFile(filepath)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			return nil, err
+		}
 	}
 
-	var config models.Config
-	if err := yaml.Unmarshal(configFile, &config); err != nil {
-		return nil, err
-	}
+	// Override with environment variables if set
+	overrideFromEnv(&cfg)
 
-	return &config, nil
+	return &cfg, nil
+}
+
+// overrideFromEnv checks for specific environment variables and overrides the corresponding fields in the Config struct if they are set
+func overrideFromEnv(cfg *models.Config) {
+	setString(&cfg.TargetFrom, "TARGET_FROM")
+	setString(&cfg.TargetSubject, "TARGET_SUBJECT")
+
+	setString(&cfg.Email.Imap, "EMAIL_IMAP")
+	setString(&cfg.Email.Login, "EMAIL_LOGIN")
+	setString(&cfg.Email.Password, "EMAIL_PASSWORD")
+	setString(&cfg.Email.MailBox, "EMAIL_MAILBOX")
+}
+
+// setString checks if the specified environment variable is set and not empty, and if so, assigns its value to the provided string pointer
+func setString(field *string, envKey string) {
+	if v, ok := os.LookupEnv(envKey); ok && v != "" {
+		*field = v
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,12 +13,6 @@ func TestLoad(t *testing.T) {
   mailbox: "INBOX"
 targetFrom: "info@test.com"
 targetSubject: "Test Subject"
-filterByAccount: true
-netflixAuth:
-  - email: user1@example.com
-    password: pass1
-  - email: user2@example.com
-    password: pass2
 `
 
 	tmpFile, err := os.CreateTemp("", "config-*.yaml")
@@ -45,17 +39,5 @@ netflixAuth:
 
 	if cfg.TargetFrom != "info@test.com" {
 		t.Errorf("Expected targetFrom 'info@test.com', got '%s'", cfg.TargetFrom)
-	}
-
-	if !cfg.FilterByAccount {
-		t.Error("Expected filterByAccount to be true")
-	}
-
-	if len(cfg.NetflixAuth) != 2 {
-		t.Errorf("Expected 2 Netflix accounts, got %d", len(cfg.NetflixAuth))
-	}
-
-	if cfg.NetflixAuth[0].Email != "user1@example.com" {
-		t.Errorf("Expected first account email 'user1@example.com', got '%s'", cfg.NetflixAuth[0].Email)
 	}
 }

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -2,11 +2,9 @@ package models
 
 // Config represents the application configuration
 type Config struct {
-	NetflixAuth     []NetflixAccount `yaml:"netflixAuth"`
-	FilterByAccount bool             `yaml:"filterByAccount"`
-	Email           EmailConfig      `yaml:"email"`
-	TargetFrom      string           `yaml:"targetFrom"`
-	TargetSubject   string           `yaml:"targetSubject"`
+	Email         EmailConfig `yaml:"email"`
+	TargetFrom    string      `yaml:"targetFrom"`
+	TargetSubject string      `yaml:"targetSubject"`
 }
 
 // EmailConfig represents IMAP email configuration
@@ -15,10 +13,4 @@ type EmailConfig struct {
 	Login    string `yaml:"login"`
 	Password string `yaml:"password"`
 	MailBox  string `yaml:"mailbox"`
-}
-
-// NetflixAccount represents Netflix account credentials
-type NetflixAccount struct {
-	Email    string `yaml:"email"`
-	Password string `yaml:"password"`
 }

--- a/internal/netflix/browser.go
+++ b/internal/netflix/browser.go
@@ -3,5 +3,5 @@ package netflix
 import "netflix-household-validator/internal/models"
 
 type Browser interface {
-OpenUpdatePrimaryLocation(link, email, password string, traceID string) (models.BrowserResult, error)
+	OpenUpdatePrimaryLocation(link, traceID string) (models.BrowserResult, error)
 }

--- a/internal/netflix/browser_rod.go
+++ b/internal/netflix/browser_rod.go
@@ -1,6 +1,7 @@
 package netflix
 
 import (
+	"net/url"
 	"netflix-household-validator/internal/models"
 	"os"
 	"path/filepath"
@@ -23,15 +24,16 @@ func NewRodBrowser() *RodBrowser {
 }
 
 // OpenUpdatePrimaryLocation attempts to open the provided link using Rod, handling login if necessary.
-func (rb *RodBrowser) OpenUpdatePrimaryLocation(link, netflixEmail, netflixPassword string, traceID string) (models.BrowserResult, error) {
+func (rb *RodBrowser) OpenUpdatePrimaryLocation(link, traceID string) (models.BrowserResult, error) {
 	const maxAttempts = 3
 
-	logging.Log.WithField("trace_id", traceID).Info("Open page with rod: ", link)
+	sanitizedLink := sanitizeURL(link)
+	logging.Log.WithField("trace_id", traceID).Info("Open page with rod: ", sanitizedLink)
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		logging.Log.WithField("trace_id", traceID).Infof("Attempt %d/%d (fresh browser & profile)", attempt, maxAttempts)
 
-		result, err := rb.attemptOpenLink(link, netflixEmail, netflixPassword, attempt, traceID)
+		result, err := rb.attemptOpenLink(link, attempt, traceID)
 		if err != nil {
 			logging.Log.WithField("trace_id", traceID).WithError(err).Warnf("Attempt %d error", attempt)
 		}
@@ -57,8 +59,6 @@ func (rb *RodBrowser) OpenUpdatePrimaryLocation(link, netflixEmail, netflixPassw
 // attemptOpenLink performs a single attempt to open the link and interact with the page.
 func (rb *RodBrowser) attemptOpenLink(
 	link string,
-	netflixEmail string,
-	netflixPassword string,
 	attempt int,
 	traceID string,
 ) (models.BrowserResult, error) {
@@ -109,25 +109,11 @@ func (rb *RodBrowser) attemptOpenLink(
 	}
 
 	// Detect login form
-	loginElement, err := page.Timeout(10 * time.Second).
+	_, err = page.Timeout(10 * time.Second).
 		Element(`input[name='userLoginId']`)
 	if err == nil {
-		if netflixEmail != "" && netflixPassword != "" {
-			locallog.Info("Login fields detected, attempting to log in")
-			loginElement.MustInput(netflixEmail)
-			page.MustElement(`input[name='password']`).MustInput(netflixPassword)
-			page.MustElement(`[data-uia="login-submit-button"]`).MustClick()
-			page.MustWaitLoad()
-
-			// Cookie banner can reappear after login
-			if cookieBtn, err := page.Timeout(5 * time.Second).Element("#onetrust-accept-btn-handler"); err == nil {
-				locallog.Info("Cookie banner detected after login, accepting")
-				cookieBtn.MustClick()
-			}
-		} else {
-			locallog.Info("Login required but credentials unavailable, aborting link")
-			return models.ResultAbort, nil
-		}
+		locallog.Info("Login required but credentials unavailable, aborting link")
+		return models.ResultAbort, nil
 	}
 
 	// Try to find the confirm button: if it exists, the link is valid
@@ -181,4 +167,30 @@ func StartCleanup() {
 			}
 		}
 	}()
+}
+
+// sanitizeURL redacts sensitive query parameters from the URL for safe logging
+func sanitizeURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+
+	q := u.Query()
+
+	redactKeys := map[string]struct{}{
+		"nftoken": {},
+		"g":       {},
+	}
+
+	for key := range redactKeys {
+		if q.Has(key) {
+			q.Set(key, "******")
+		}
+	}
+
+	u.RawQuery = q.Encode()
+	u.Fragment = ""
+
+	return u.String()
 }

--- a/internal/netflix/service.go
+++ b/internal/netflix/service.go
@@ -50,31 +50,10 @@ func (s *Service) HandleEmail(email *models.Email) bool {
 			continue
 		}
 
-		// Determine credentials
-		netflixEmail := ""
-		netflixPassword := ""
-
-		if s.config.FilterByAccount {
-			found := false
-			for _, account := range s.config.NetflixAuth {
-				if account.Email == email.ToPrimary {
-					locallog.Infof("Email received for %s", account.Email)
-					netflixEmail = account.Email
-					netflixPassword = account.Password
-					found = true
-					break
-				}
-			}
-			if !found {
-				locallog.Infof("No matching Netflix account found for To: %s", email.ToPrimary)
-				return false
-			}
-		} else {
-			locallog.Infof("Email received for %s", email.ToPrimary)
-		}
+		locallog.Infof("Email received for %s", email.ToPrimary)
 
 		// Open link with browser
-		result, err := s.browser.OpenUpdatePrimaryLocation(link, netflixEmail, netflixPassword, email.TraceID)
+		result, err := s.browser.OpenUpdatePrimaryLocation(link, email.TraceID)
 		if err != nil {
 			locallog.WithError(err).Error("Browser error")
 			return false

--- a/internal/netflix/service_test.go
+++ b/internal/netflix/service_test.go
@@ -11,7 +11,7 @@ type MockBrowser struct {
 	Err    error
 }
 
-func (m *MockBrowser) OpenUpdatePrimaryLocation(_, _, _ string, _ string) (models.BrowserResult, error) {
+func (m *MockBrowser) OpenUpdatePrimaryLocation(_, _ string) (models.BrowserResult, error) {
 	return m.Result, m.Err
 }
 
@@ -109,9 +109,8 @@ func TestHandleEmail_NoUpdateLink(t *testing.T) {
 
 func TestHandleEmail_Success(t *testing.T) {
 	cfg := &models.Config{
-		TargetFrom:      "info@account.netflix.com",
-		TargetSubject:   "Test Subject",
-		FilterByAccount: false,
+		TargetFrom:    "info@account.netflix.com",
+		TargetSubject: "Test Subject",
 	}
 
 	mockBrowser := &MockBrowser{Result: models.ResultSuccess}
@@ -132,66 +131,10 @@ func TestHandleEmail_Success(t *testing.T) {
 	}
 }
 
-func TestHandleEmail_FilterByAccount_Match(t *testing.T) {
-	cfg := &models.Config{
-		TargetFrom:      "info@account.netflix.com",
-		TargetSubject:   "Test Subject",
-		FilterByAccount: true,
-		NetflixAuth: []models.NetflixAccount{
-			{Email: "user1@example.com", Password: "pass1"},
-			{Email: "user2@example.com", Password: "pass2"},
-		},
-	}
-
-	mockBrowser := &MockBrowser{Result: models.ResultSuccess}
-	svc := NewService(mockBrowser, cfg)
-
-	email := &models.Email{
-		From:      "info@account.netflix.com",
-		Subject:   "Test Subject",
-		BodyText:  "https://netflix.com/update-primary-location?token=abc",
-		ToPrimary: "user2@example.com",
-		TraceID:   "test-trace",
-	}
-
-	handled := svc.HandleEmail(email)
-	if !handled {
-		t.Error("Expected email to be handled for matching account")
-	}
-}
-
-func TestHandleEmail_FilterByAccount_NoMatch(t *testing.T) {
-	cfg := &models.Config{
-		TargetFrom:      "info@account.netflix.com",
-		TargetSubject:   "Test Subject",
-		FilterByAccount: true,
-		NetflixAuth: []models.NetflixAccount{
-			{Email: "user1@example.com", Password: "pass1"},
-		},
-	}
-
-	mockBrowser := &MockBrowser{Result: models.ResultSuccess}
-	svc := NewService(mockBrowser, cfg)
-
-	email := &models.Email{
-		From:      "info@account.netflix.com",
-		Subject:   "Test Subject",
-		BodyText:  "https://netflix.com/update-primary-location?token=abc",
-		ToPrimary: "unknown@example.com",
-		TraceID:   "test-trace",
-	}
-
-	handled := svc.HandleEmail(email)
-	if handled {
-		t.Error("Expected email to be rejected due to no matching account")
-	}
-}
-
 func TestHandleEmail_BrowserResultExpired(t *testing.T) {
 	cfg := &models.Config{
-		TargetFrom:      "info@account.netflix.com",
-		TargetSubject:   "Test Subject",
-		FilterByAccount: false,
+		TargetFrom:    "info@account.netflix.com",
+		TargetSubject: "Test Subject",
 	}
 
 	mockBrowser := &MockBrowser{Result: models.ResultExpired}
@@ -213,9 +156,8 @@ func TestHandleEmail_BrowserResultExpired(t *testing.T) {
 
 func TestHandleEmail_BrowserResultAbort(t *testing.T) {
 	cfg := &models.Config{
-		TargetFrom:      "info@account.netflix.com",
-		TargetSubject:   "Test Subject",
-		FilterByAccount: false,
+		TargetFrom:    "info@account.netflix.com",
+		TargetSubject: "Test Subject",
 	}
 
 	mockBrowser := &MockBrowser{Result: models.ResultAbort}


### PR DESCRIPTION
- remove filterByAccount and netflixAuth config fields
- add environment variable overrides for email and target settings
- stop attempting browser login when auth is required
- sanitize sensitive query params in logged URLs