### PR TITLE
Fix using packed chromium

### DIFF
--- a/internal/netflix/browser_rod.go
+++ b/internal/netflix/browser_rod.go
@@ -83,6 +83,11 @@ func (rb *RodBrowser) attemptOpenLink(
 		NoSandbox(true).
 		UserDataDir(tmpDir)
 
+	const systemChromium = "/usr/bin/chromium"
+	if _, err := os.Stat(systemChromium); err == nil {
+		u = u.Bin(systemChromium)
+	}
+
 	launchURL, err := u.Launch()
 	if err != nil {
 		locallog.WithError(err).Error("failed to launch browser")


### PR DESCRIPTION
When running in docker, currently rod downloads chromium when processing the first mail. Due to the fact that chromium already is packed inside the image, we can check for this _systemChromium_ to use instead of downloading it again.

This speeds up processing the first mail when running in docker.