### PR TITLE
fix(imap): use BODY.PEEK to prevent marking all emails as read

### DIFF
--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -88,7 +88,7 @@ func (c *StandardClient) FetchMessage(uid uint32) (*imap.Message, error) {
 	seqSet := new(imap.SeqSet)
 	seqSet.AddNum(uid)
 
-	section := &imap.BodySectionName{}
+	section := &imap.BodySectionName{Peek: true}
 	items := []imap.FetchItem{section.FetchItem(), imap.FetchInternalDate, imap.FetchUid}
 
 	prevTimeout := c.client.Timeout


### PR DESCRIPTION
`go-imap` with "Peek: false" (which is a default if not specified) is causing all mail to be marked as seen in Gmail. By adding this attr only one (correct) email is marked as read after button is clicked.